### PR TITLE
Adding required UI changes

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,3 +1,4 @@
+import { LucideProps } from "lucide-react";
 import React from "react";
 
 type IconProps = React.HTMLAttributes<SVGElement>;
@@ -1277,6 +1278,22 @@ export const Icons = {
         stroke-miterlimit="10"
         stroke-linecap="round"
         stroke-linejoin="round"
+      />
+    </svg>
+  ),
+  shield: (props: LucideProps) => (
+    <svg
+      {...props}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 22C12 22 20 18 20 12V5L12 2L4 5V12C4 18 12 22 12 22Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   ),

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -22,6 +22,7 @@ import {
 } from "./ui/tabs";
 import Unstake from "./unstake";
 import WithdrawLog from "./withdraw-log";
+import { Icons } from "./Icons";
 
 interface TabsProps {
   avgWaitTime: string;
@@ -60,9 +61,27 @@ const Tabs: React.FC<TabsProps> = ({ avgWaitTime }) => {
 
   return (
     <>
+      <div className={cn("w-full max-w-xl", {
+        "lg:-ml-32": open,
+      })}>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <Icons.strkLogo className="size-8" />
+            <h1 className="text-2xl font-bold text-black">Stake STRK</h1>
+          </div>
+          <div className="flex items-center gap-1 rounded-full border border-[#17876D33] bg-[#17876D1A] px-3 py-1">
+            <Icons.shield className="size-4 text-[#17876D]" />
+            <span className="text-sm text-[#17876D]">Secure and audited</span>
+          </div>
+        </div>
+
+        <p className="mt-2 text-[#8D9C9C]">
+          Convert your STRK into xSTRK to earn staking rewards and participate in DeFi opportunities across the Starknet ecosystem.
+        </p>
+      </div>
       <div
         className={cn(
-          "mt-12 min-h-[31.5rem] w-full max-w-xl rounded-xl bg-white shadow-xl lg:h-[36.3rem] xl:mt-6",
+          "mt-6 min-h-[31.5rem] w-full max-w-xl rounded-xl bg-white shadow-xl lg:h-[37rem] xl:mt-6",
           {
             "lg:-ml-32": open,
           },

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -69,10 +69,14 @@ const Tabs: React.FC<TabsProps> = ({ avgWaitTime }) => {
             <Icons.strkLogo className="size-8" />
             <h1 className="text-2xl font-bold text-black">Stake STRK</h1>
           </div>
-          <div className="flex items-center gap-1 rounded-full border border-[#17876D33] bg-[#17876D1A] px-3 py-1">
+          <Link
+            href="https://endur.fi/audit"
+            target="_blank"
+            className="flex items-center gap-1 rounded-full border border-[#17876D33] bg-[#17876D1A] px-3 py-1 transition-opacity hover:opacity-80"
+          >
             <Icons.shield className="size-4 text-[#17876D]" />
             <span className="text-sm text-[#17876D]">Secure and audited</span>
-          </div>
+          </Link>
         </div>
 
         <p className="mt-2 text-[#8D9C9C]">

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -105,7 +105,7 @@ export function AppSidebar({ className }: { className?: string }) {
                     <Icons.defiLight className="hidden size-5 group-hover/defi:flex" />
                   </>
                 )}
-                DeFi <span className="text-sm font-thin">(coming soon)</span>
+                DeFi <span className="text-sm font-thin">with xSTRK</span>
               </SidebarGroup>
             </Link>
 
@@ -191,7 +191,7 @@ export function AppSidebar({ className }: { className?: string }) {
                 side="right"
                 className="rounded-md border border-[#03624C] bg-[#E3EEEC] text-[#03624C]"
               >
-                <p>DeFi (coming soon)</p>
+                <p>xSTRK on DeFi</p>
               </TooltipContent>
             </Tooltip>
 

--- a/src/components/defi-card.tsx
+++ b/src/components/defi-card.tsx
@@ -1,16 +1,22 @@
-import Link from "next/link";
-import { Button } from "./ui/button";
 import React from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-
-interface TokenDisplay {
+export interface TokenDisplay {
   icon: React.ReactNode;
   name: string;
 }
 
-interface ProtocolBadge {
+export interface ProtocolBadge {
   type: string;
   color: string;
+}
+
+export interface ProtocolAction {
+  type: string;
+  link: string;
+  buttonText: string;
+  primary?: boolean;
 }
 
 interface DefiCardProps {
@@ -23,7 +29,7 @@ interface DefiCardProps {
     error: boolean;
     value: number | null;
   };
-  link?: string;
+  actions: ProtocolAction[];
 }
 
 const TokenPairDisplay: React.FC<{ tokens: TokenDisplay[] }> = ({ tokens }) => (
@@ -74,16 +80,55 @@ const ProtocolBadges: React.FC<{ badges: ProtocolBadge[] }> = ({ badges }) => (
   </div>
 );
 
+const ActionButton: React.FC<{ action: ProtocolAction }> = ({ action }) => {
+  const baseStyles = "w-full rounded-full px-4 py-2.5 text-sm font-medium transition-colors";
+  
+  const styles = action.primary
+    ? "bg-[#17876D] text-white hover:bg-[#146D57]"
+    : "bg-[#E9F3F0] text-[#17876D] hover:bg-[#D7E8E3]";
+
+  return (
+    <Link
+      href={action.link}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex-1"
+    >
+      <Button className={cn(baseStyles, styles)}>
+        {action.buttonText}
+      </Button>
+    </Link>
+  );
+};
+
+const ActionButtons: React.FC<{ actions: ProtocolAction[] }> = ({ actions }) => {
+  if (actions.length === 0) {
+    return (
+      <Button className="w-full rounded-full bg-[#03624C4D] px-4 py-2.5 text-sm font-medium text-[#17876D] hover:bg-[#03624C4D]">
+        Coming soon
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {actions.map((action, index) => (
+        <ActionButton key={index} action={action} />
+      ))}
+    </div>
+  );
+};
+
 const DefiCard: React.FC<DefiCardProps> = ({
   tokens,
   protocolIcon,
   badges,
   description,
   apy,
-  link
+  actions
 }) => {
   return (
-    <div className="flex h-[200px] w-full min-w-[330px] flex-col rounded-xl bg-white p-5">
+    <div className="flex h-auto min-h-[200px] w-full min-w-[330px] flex-col rounded-xl bg-white p-5">
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-2">
           <TokenPairDisplay tokens={tokens} />
@@ -98,23 +143,8 @@ const DefiCard: React.FC<DefiCardProps> = ({
 
       <h3 className="mt-4 text-sm text-[#4B5563]">{description}</h3>
 
-      <div className="mt-auto">
-        {link ? (
-          <Link
-            href={link} 
-            target="_blank" 
-            rel="noopener noreferrer" 
-            className="w-full"
-          >
-            <Button className="w-full rounded-full bg-[#17876D] px-4 py-2 text-xs font-medium text-white hover:bg-[#146D57] transition-colors">
-              Launch App
-            </Button>
-          </Link>
-        ) : (
-          <Button className="w-full rounded-full bg-[#03624C4D] px-4 py-2 text-xs font-medium text-[#17876D] hover:bg-[#03624C4D]">
-            Coming soon
-          </Button>
-        )}
+      <div className="mt-auto pt-4">
+        <ActionButtons actions={actions} />
       </div>
     </div>
   );

--- a/src/components/defi-card.tsx
+++ b/src/components/defi-card.tsx
@@ -16,7 +16,7 @@ export interface ProtocolAction {
   type: string;
   link: string;
   buttonText: string;
-  primary?: boolean;
+  variant?: 'primary' | 'secondary' | 'tertiary';  // Added variant instead of boolean primary
 }
 
 interface DefiCardProps {
@@ -81,18 +81,22 @@ const ProtocolBadges: React.FC<{ badges: ProtocolBadge[] }> = ({ badges }) => (
 );
 
 const ActionButton: React.FC<{ action: ProtocolAction }> = ({ action }) => {
-  const baseStyles = "w-full rounded-full px-4 py-2.5 text-sm font-medium transition-colors";
+  const baseStyles = "grow rounded-xl px-4 py-2.5 text-sm font-medium transition-all";
   
-  const styles = action.primary
-    ? "bg-[#17876D] text-white hover:bg-[#146D57]"
-    : "bg-[#E9F3F0] text-[#17876D] hover:bg-[#D7E8E3]";
+  const variantStyles = {
+    primary: "bg-[#17876D] text-white hover:bg-[#146D57]",
+    secondary: "bg-[#E9F3F0] text-[#17876D] border border-[#17876D33] hover:bg-[#DBE9E4]",
+    tertiary: "bg-white text-[#17876D] border border-[#17876D33] hover:bg-[#F7FAF9]"
+  };
+
+  const styles = variantStyles[action.variant || 'primary'];
 
   return (
     <Link
       href={action.link}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex-1"
+      className="flex min-w-0 flex-1 basis-0"
     >
       <Button className={cn(baseStyles, styles)}>
         {action.buttonText}
@@ -104,21 +108,60 @@ const ActionButton: React.FC<{ action: ProtocolAction }> = ({ action }) => {
 const ActionButtons: React.FC<{ actions: ProtocolAction[] }> = ({ actions }) => {
   if (actions.length === 0) {
     return (
-      <Button className="w-full rounded-full bg-[#03624C4D] px-4 py-2.5 text-sm font-medium text-[#17876D] hover:bg-[#03624C4D]">
+      <Button className="w-full rounded-xl bg-[#E9F3F0] px-4 py-2.5 text-sm font-medium text-[#17876D] hover:bg-[#DBE9E4]">
         Coming soon
       </Button>
     );
   }
 
+  // For single button, use full width
+  if (actions.length === 1) {
+    return (
+      <Link
+        href={actions[0].link}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block w-full"
+      >
+        <Button 
+          className={cn(
+            "w-full rounded-xl px-4 py-2.5 text-sm font-medium transition-all",
+            "bg-[#17876D] text-white hover:bg-[#146D57]"
+          )}
+        >
+          {actions[0].buttonText}
+        </Button>
+      </Link>
+    );
+  }
+
+  // For multiple buttons, use grid layout
   return (
-    <div className="flex flex-col gap-2">
+    <div className="grid grid-cols-3 gap-3">
       {actions.map((action, index) => (
-        <ActionButton key={index} action={action} />
+        <Link
+          key={index}
+          href={action.link}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Button 
+            className={cn(
+              "w-full rounded-xl px-4 py-2.5 text-sm font-medium transition-all",
+              {
+                "bg-[#17876D] text-white hover:bg-[#146D57]": index === 0,
+                "bg-[#E9F3F0] text-[#17876D] border border-[#17876D33] hover:bg-[#DBE9E4]": index === 1,
+                "bg-white text-[#17876D] border border-[#17876D33] hover:bg-[#F7FAF9]": index === 2
+              }
+            )}
+          >
+            {action.buttonText}
+          </Button>
+        </Link>
       ))}
     </div>
   );
 };
-
 const DefiCard: React.FC<DefiCardProps> = ({
   tokens,
   protocolIcon,

--- a/src/components/defi-card.tsx
+++ b/src/components/defi-card.tsx
@@ -1,11 +1,44 @@
-import Image from "next/image";
+import Link from "next/link";
 import React from "react";
 
 import { Icons } from "./Icons";
 import { Button } from "./ui/button";
+import { cn } from "@/lib/utils";
+
+const defiLinks = {
+  strkfarm: "",  // not yet available
+  vesu: "https://vesu.xyz/lend",
+  avnu: "https://app.avnu.fi/en?mode=simple&tokenFrom=0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d&tokenTo=0x28d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a&amount=0.001",
+  fibrous: "https://app.fibrous.finance/en?network=starknet&mode=swap&source=0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d&destination=0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a",
+  ekubo: "https://app.ekubo.org/positions/new?baseCurrency=xSTRK&quoteCurrency=STRK&fee=170141183460469235273462165868118016&tickSpacing=1000&poolOnly=true"
+} as const;
+
+interface ProtocolBadge {
+  type: string;
+  color: string;
+}
+
+const protocolTypes: Record<string, ProtocolBadge[]> = {
+  strkfarm: [{ type: "Yield Farming", color: "bg-[#E9F3F0] text-[#17876D]" }],
+  vesu: [{ type: "Lend/Borrow", color: "bg-[#EEF6FF] text-[#0369A1]" }],
+  avnu: [{ type: "DEX Aggregator", color: "bg-[#F3E8FF] text-[#9333EA]" }],
+  fibrous: [{ type: "DEX Aggregator", color: "bg-[#F3E8FF] text-[#9333EA]" }],
+  ekubo: [
+    { type: "DEX", color: "bg-[#F3E8FF] text-[#9333EA]" },
+    { type: "Liquidity", color: "bg-[#FFF7ED] text-[#EA580C]" }  
+  ],
+};
+
+const mockYields = {
+  strkfarm: "8.2%",
+  vesu: "12.4%",
+  avnu: "5.6%",
+  fibrous: "6.8%",
+  ekubo: "9.3%"
+};
 
 interface DefiCardProps {
-  dapp: string;
+  dapp: keyof typeof defiLinks;
   tokens: [string, string];
   description: string;
 }
@@ -14,17 +47,17 @@ const DefiCard: React.FC<DefiCardProps> = ({ dapp, tokens, description }) => {
   const getDappIcon = (dappName: string) => {
     switch (dappName.toLowerCase()) {
       case "endur":
-        return <Icons.endurLogo />;
+        return <Icons.endurLogo className="size-8" />;
       case "strkfarm":
-        return <Icons.strkfarmLogo />;
+        return <Icons.strkfarmLogo className="size-8" />;
       case "vesu":
-        return <Icons.vesuLogo className="rounded-full" />;
+        return <Icons.vesuLogo className="size-8 rounded-full" />;
       case "avnu":
-        return <Icons.avnuLogo className="rounded-full border" />;
+        return <Icons.avnuLogo className="size-8 rounded-full border" />;
       case "fibrous":
-        return <Icons.fibrousLogo className="rounded-full" />;
+        return <Icons.fibrousLogo className="size-8 rounded-full" />;
       case "ekubo":
-        return <Icons.ekuboLogo className="rounded-full" />;
+        return <Icons.ekuboLogo className="size-8 rounded-full" />;
       default:
         return null;
     }
@@ -35,47 +68,71 @@ const DefiCard: React.FC<DefiCardProps> = ({ dapp, tokens, description }) => {
       case "strk":
         return <Icons.strkLogo className="size-[22px]" />;
       case "xstrk":
-        return <Icons.endurLogo />;
+        return <Icons.endurLogo className="size-[22px]" />;
       case "usdc":
-        return <Icons.usdcLogo />;
+        return <Icons.usdcLogo className="size-[22px]" />;
       default:
         return null;
     }
   };
 
+  const isDex = ["avnu", "fibrous", "ekubo"].includes(dapp);
+  const link = defiLinks[dapp];
+
   return (
-    <div className="h-[230px] w-full min-w-[330px] rounded-xl bg-white px-4 py-3">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-sm">
-          <div className="flex items-center">
+    <div className="flex h-[200px] w-full min-w-[330px] flex-col rounded-xl bg-white p-5">
+      <div className="flex items-start justify-between">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
             {getTokenIcon(tokens[0])}
-            {getTokenIcon(tokens[1]) && (
-              <div className="-ml-2 size-6 rounded-full border-[1.5px] border-white bg-white">
-                {getTokenIcon(tokens[1])}
-              </div>
-            )}
+            <span className="text-sm font-medium">
+              {isDex ? "xSTRK/STRK" : tokens[0]}
+            </span>
           </div>
-          {tokens[0]}
-          {getTokenIcon(tokens[1]) && `-${tokens[1]}`}
+          
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-[#8D9C9C]">APY</span>
+            <span className="text-lg font-semibold text-[#17876D]">
+              {mockYields[dapp]}
+            </span>
+          </div>
         </div>
-
-        {getDappIcon(dapp)}
+        
+        <div className="flex items-start gap-2">
+          <div className="flex flex-wrap gap-1.5 justify-end max-w-[180px]">
+            {protocolTypes[dapp].map((badge, index) => (
+              <div
+                key={index}
+                className={cn("rounded-full px-2.5 py-1 text-xs whitespace-nowrap", badge.color)}
+              >
+                {badge.type}
+              </div>
+            ))}
+          </div>
+          {getDappIcon(dapp)}
+        </div>
       </div>
 
-      <p className="mt-4 text-sm text-black">{description}</p>
+      <h3 className="mt-4 text-sm text-[#4B5563]">{description}</h3>
 
-      <div className="relative h-[69px] w-full">
-        <Image
-          className="mt-2 object-contain"
-          src="/blur.svg"
-          fill
-          alt="blur"
-        />
+      <div className="mt-auto">
+        {link ? (
+          <Link 
+            href={link} 
+            target="_blank" 
+            rel="noopener noreferrer" 
+            className="w-full"
+          >
+            <Button className="w-full rounded-full bg-[#17876D] px-4 py-2 text-xs font-medium text-white hover:bg-[#146D57] transition-colors">
+              Launch App
+            </Button>
+          </Link>
+        ) : (
+          <Button className="w-full rounded-full bg-[#03624C4D] px-4 py-2 text-xs font-medium text-[#17876D] hover:bg-[#03624C4D]">
+            Coming soon
+          </Button>
+        )}
       </div>
-
-      <Button className="mt-8 w-full rounded-full bg-[#03624C4D] text-[13px] font-bold tracking-[-1%] text-[#17876D] hover:bg-[#03624C4D]">
-        Coming soon
-      </Button>
     </div>
   );
 };

--- a/src/components/defi-card.tsx
+++ b/src/components/defi-card.tsx
@@ -1,138 +1,98 @@
-import { useAtomValue } from "jotai";
 import Link from "next/link";
-import React from "react";
-
-import { Icons } from "./Icons";
 import { Button } from "./ui/button";
+import React from "react";
 import { cn } from "@/lib/utils";
-import { protocolYieldsAtom } from "@/store/defi.store";
 
-const defiLinks = {
-  strkfarm: "",  // not yet available
-  vesu: "https://vesu.xyz/lend",
-  avnu: "https://app.avnu.fi/en?mode=simple&tokenFrom=0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d&tokenTo=0x28d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a&amount=0.001",
-  fibrous: "https://app.fibrous.finance/en?network=starknet&mode=swap&source=0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d&destination=0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a",
-  ekubo: "https://app.ekubo.org/positions/new?baseCurrency=xSTRK&quoteCurrency=STRK&fee=170141183460469235273462165868118016&tickSpacing=1000&poolOnly=true"
-} as const;
+interface TokenDisplay {
+  icon: React.ReactNode;
+  name: string;
+}
 
 interface ProtocolBadge {
   type: string;
   color: string;
 }
 
-const protocolTypes: Record<string, ProtocolBadge[]> = {
-  strkfarm: [{ type: "Yield Farming", color: "bg-[#E9F3F0] text-[#17876D]" }],
-  vesu: [{ type: "Lend/Borrow", color: "bg-[#EEF6FF] text-[#0369A1]" }],
-  avnu: [{ type: "DEX Aggregator", color: "bg-[#F3E8FF] text-[#9333EA]" }],
-  fibrous: [{ type: "DEX Aggregator", color: "bg-[#F3E8FF] text-[#9333EA]" }],
-  ekubo: [
-    { type: "DEX", color: "bg-[#F3E8FF] text-[#9333EA]" },
-    { type: "Liquidity", color: "bg-[#FFF7ED] text-[#EA580C]" }
-  ],
-};
-
-type ProtocolType = "dexAggregator" | "lending" | "farming" | "lpAndDex";
-
-const protocolCategories: Record<keyof typeof defiLinks, ProtocolType> = {
-  strkfarm: "farming",
-  vesu: "lending",
-  avnu: "dexAggregator",
-  fibrous: "dexAggregator",
-  ekubo: "lpAndDex"
-};
-
 interface DefiCardProps {
-  dapp: keyof typeof defiLinks;
-  tokens: [string, string];
+  tokens: TokenDisplay[];
+  protocolIcon: React.ReactNode;
+  badges: ProtocolBadge[];
   description: string;
+  apy?: {
+    isLoading: boolean;
+    error: boolean;
+    value: number | null;
+  };
+  link?: string;
 }
 
-const DefiCard: React.FC<DefiCardProps> = ({ dapp, tokens, description }) => {
-  const yields = useAtomValue(protocolYieldsAtom);
-  const yieldData = yields[dapp];
-  const protocolType = protocolCategories[dapp];
+const TokenPairDisplay: React.FC<{ tokens: TokenDisplay[] }> = ({ tokens }) => (
+  <div className="flex items-center gap-2">
+    <div className="flex items-center">
+      {tokens[0].icon}
+      {tokens[1]?.icon && (
+        <div className="-ml-2 size-6 rounded-full border-[1.5px] border-white bg-white">
+          {tokens[1].icon}
+        </div>
+      )}
+    </div>
+    <span className="text-sm font-medium">
+      {tokens.map(t => t.name).join("/")}
+    </span>
+  </div>
+);
 
-  const getDappIcon = (dappName: string) => {
-    switch (dappName.toLowerCase()) {
-      case "endur":
-        return <Icons.endurLogo className="size-8" />;
-      case "strkfarm":
-        return <Icons.strkfarmLogo className="size-8" />;
-      case "vesu":
-        return <Icons.vesuLogo className="size-8 rounded-full" />;
-      case "avnu":
-        return <Icons.avnuLogo className="size-8 rounded-full border" />;
-      case "fibrous":
-        return <Icons.fibrousLogo className="size-8 rounded-full" />;
-      case "ekubo":
-        return <Icons.ekuboLogo className="size-8 rounded-full" />;
-      default:
-        return null;
-    }
+const ApyDisplay: React.FC<{ apy: DefiCardProps['apy'] }> = ({ apy }) => {
+  if (!apy) return null;
+
+  const renderValue = () => {
+    if (apy.isLoading) return "Loading...";
+    if (apy.error || apy.value === null) return "-";
+    return `${apy.value.toFixed(2)}%`;
   };
 
-  const getTokenIcon = (tokenName: string) => {
-    switch (tokenName.toLowerCase()) {
-      case "strk":
-        return <Icons.strkLogo className="size-[22px]" />;
-      case "xstrk":
-        return <Icons.endurLogo className="size-[22px]" />;
-      case "usdc":
-        return <Icons.usdcLogo className="size-[22px]" />;
-      default:
-        return null;
-    }
-  };
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-[#8D9C9C]">APY</span>
+      <span className="text-lg font-semibold text-[#17876D]">
+        {renderValue()}
+      </span>
+    </div>
+  );
+};
 
-  const isDex = ["avnu", "fibrous", "ekubo"].includes(dapp);
-  const link = defiLinks[dapp];
+const ProtocolBadges: React.FC<{ badges: ProtocolBadge[] }> = ({ badges }) => (
+  <div className="flex flex-wrap gap-1.5 justify-end max-w-[180px]">
+    {badges.map((badge, index) => (
+      <div
+        key={index}
+        className={cn("rounded-full px-2.5 py-1 text-xs whitespace-nowrap", badge.color)}
+      >
+        {badge.type}
+      </div>
+    ))}
+  </div>
+);
 
-  const renderAPY = () => {
-    if (yieldData.isLoading) return "Loading...";
-    if (yieldData.error || yieldData.value === null) return "-";
-    return `${yieldData.value.toFixed(2)}%`;
-  };
-
+const DefiCard: React.FC<DefiCardProps> = ({
+  tokens,
+  protocolIcon,
+  badges,
+  description,
+  apy,
+  link
+}) => {
   return (
     <div className="flex h-[200px] w-full min-w-[330px] flex-col rounded-xl bg-white p-5">
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-2">
-          <div className="flex items-center">
-            {getTokenIcon(tokens[0])}
-            {getTokenIcon(tokens[1]) && (
-              <div className="-ml-2 size-6 rounded-full border-[1.5px] border-white bg-white">
-                {getTokenIcon(tokens[1])}
-              </div>
-            )}
-          </div>
-            <span className="text-sm font-medium">
-              {isDex ? "xSTRK/STRK" : tokens[0]}
-            </span>
-          </div>
-          
-          {protocolType !== "dexAggregator" && (
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-[#8D9C9C]">APY</span>
-              <span className="text-lg font-semibold text-[#17876D]">
-                {renderAPY()}
-              </span>
-            </div>
-          )}
+          <TokenPairDisplay tokens={tokens} />
+          <ApyDisplay apy={apy} />
         </div>
         
         <div className="flex items-center gap-2">
-          <div className="flex flex-wrap gap-1.5 justify-end max-w-[180px]">
-            {protocolTypes[dapp].map((badge, index) => (
-              <div
-                key={index}
-                className={cn("rounded-full px-2.5 py-1 text-xs whitespace-nowrap", badge.color)}
-              >
-                {badge.type}
-              </div>
-            ))}
-          </div>
-          {getDappIcon(dapp)}
+          <ProtocolBadges badges={badges} />
+          {protocolIcon}
         </div>
       </div>
 
@@ -140,7 +100,7 @@ const DefiCard: React.FC<DefiCardProps> = ({ dapp, tokens, description }) => {
 
       <div className="mt-auto">
         {link ? (
-          <Link 
+          <Link
             href={link} 
             target="_blank" 
             rel="noopener noreferrer" 

--- a/src/components/defi.tsx
+++ b/src/components/defi.tsx
@@ -90,20 +90,20 @@ const protocolConfigs: Record<string, ProtocolConfig> = {
     description: "Provide liquidity to the xSTRK/STRK pool, use xSTRK as collateral and swap xSTRK on Nostra",
     actions: [
       {
-        type: "swap",
-        link: "https://app.nostra.finance/swap",
-        buttonText: "Swap Tokens",
-        primary: true
-      },
-      {
         type: "pool",
         link: "https://app.nostra.finance/pools/xSTRK-STRK/deposit",
-        buttonText: "Add Liquidity"
+        buttonText: "Add Liquidity",
+        primary: true
       },
       {
         type: "lend",
         link: "https://app.nostra.finance/lend-borrow/xSTRK/deposit",
         buttonText: "Lend Assets"
+      },
+      {
+        type: "swap",
+        link: "https://app.nostra.finance/swap",
+        buttonText: "Swap Tokens"
       }
     ]
   }
@@ -125,6 +125,14 @@ const Defi: React.FC = () => {
       </p>
 
       <div className="mt-9">
+        <div className="mb-6 rounded-md border border-[#17876D33] bg-[#17876D0A] p-4">
+          <p className="text-sm text-[#03624C]">
+            Please note: The protocols listed here are third-party services not affiliated with or endorsed by Endur.
+            This list is provided for informational convenience only. Always do your own research and understand the risks
+            before using any DeFi protocol.
+          </p>
+        </div>
+
         <p className="text-2xl font-normal tracking-[-1%] text-black">
           Opportunities
         </p>
@@ -133,7 +141,7 @@ const Defi: React.FC = () => {
           {(Object.keys(protocolConfigs) as Array<keyof typeof protocolConfigs>).map((protocol) => {
             const config = protocolConfigs[protocol];
             const shouldShowApy = !["avnu", "fibrous"].includes(protocol);
-            
+
             return (
               <DefiCard
                 key={protocol}

--- a/src/components/defi.tsx
+++ b/src/components/defi.tsx
@@ -1,29 +1,30 @@
 "use client";
 
-import { useAtomValue } from "jotai";
 import React from "react";
+import { useAtomValue } from "jotai";
 import { cn } from "@/lib/utils";
-import DefiCard from "./defi-card";
-import { Icons } from "./Icons";
-import { useSidebar } from "./ui/sidebar";
+import DefiCard, { ProtocolAction, ProtocolBadge, TokenDisplay } from "./defi-card";
+import { useSidebar } from "@/components/ui/sidebar";
 import { protocolYieldsAtom } from "@/store/defi.store";
+import { Icons } from "./Icons";
 
-const defiLinks = {
-  strkfarm: "",  // not yet available
-  vesu: "https://vesu.xyz/lend",
-  avnu: "https://app.avnu.fi/en?mode=simple&tokenFrom=0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d&tokenTo=0x28d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a&amount=0.001",
-  fibrous: "https://app.fibrous.finance/en?network=starknet&mode=swap&source=0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d&destination=0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a",
-  ekubo: "https://app.ekubo.org/positions/new?baseCurrency=xSTRK&quoteCurrency=STRK&fee=170141183460469235273462165868118016&tickSpacing=1000&poolOnly=true"
-} as const;
+interface ProtocolConfig {
+  tokens: TokenDisplay[];
+  protocolIcon: React.ReactNode;
+  badges: ProtocolBadge[];
+  description: string;
+  actions: ProtocolAction[];
+}
 
-const protocolConfigs = {
+const protocolConfigs: Record<string, ProtocolConfig> = {
   strkfarm: {
     tokens: [
       { icon: <Icons.endurLogo className="size-[22px]" />, name: "xSTRK" }
     ],
     protocolIcon: <Icons.strkfarmLogo className="size-8" />,
     badges: [{ type: "Yield Farming", color: "bg-[#E9F3F0] text-[#17876D]" }],
-    description: "Auto compound defi spring rewards on xSTRK"
+    description: "Auto compound defi spring rewards on xSTRK",
+    actions: []
   },
   vesu: {
     tokens: [
@@ -31,7 +32,15 @@ const protocolConfigs = {
     ],
     protocolIcon: <Icons.vesuLogo className="size-8 rounded-full" />,
     badges: [{ type: "Lend/Borrow", color: "bg-[#EEF6FF] text-[#0369A1]" }],
-    description: "Earn DeFi Spring rewards & yield, use xSTRK as collateral to Borrow and Multiply"
+    description: "Earn DeFi Spring rewards & yield, use xSTRK as collateral to Borrow and Multiply",
+    actions: [
+      {
+        type: "lend",
+        link: "https://vesu.xyz/lend",
+        buttonText: "Lend xSTRK",
+        primary: true
+      }
+    ]
   },
   avnu: {
     tokens: [
@@ -40,7 +49,15 @@ const protocolConfigs = {
     ],
     protocolIcon: <Icons.avnuLogo className="size-8 rounded-full border" />,
     badges: [{ type: "DEX Aggregator", color: "bg-[#F3E8FF] text-[#9333EA]" }],
-    description: "Swap xSTRK for STRK on Avnu"
+    description: "Swap xSTRK for STRK on Avnu",
+    actions: [
+      {
+        type: "swap",
+        link: "https://app.avnu.fi/en?mode=simple&tokenFrom=0x28d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a&tokenTo=0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d&amount=100",
+        buttonText: "Swap Tokens",
+        primary: true
+      }
+    ]
   },
   fibrous: {
     tokens: [
@@ -49,19 +66,15 @@ const protocolConfigs = {
     ],
     protocolIcon: <Icons.fibrousLogo className="size-8 rounded-full" />,
     badges: [{ type: "DEX Aggregator", color: "bg-[#F3E8FF] text-[#9333EA]" }],
-    description: "Swap xSTRK for STRK on Fibrous"
-  },
-  ekubo: {
-    tokens: [
-      { icon: <Icons.endurLogo className="size-[22px]" />, name: "xSTRK" },
-      { icon: <Icons.strkLogo className="size-[22px]" />, name: "STRK" }
-    ],
-    protocolIcon: <Icons.ekuboLogo className="size-8 rounded-full" />,
-    badges: [
-      { type: "DEX", color: "bg-[#F3E8FF] text-[#9333EA]" },
-      { type: "Liquidity Pool", color: "bg-[#FFF7ED] text-[#EA580C]" }
-    ],
-    description: "Provide liquidity for xSTRK/STRK on Ekubo"
+    description: "Swap xSTRK for STRK on Fibrous",
+    actions: [
+      {
+        type: "swap",
+        link: "https://app.fibrous.finance/en?network=starknet&mode=swap&source=0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a&destination=0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        buttonText: "Swap Tokens",
+        primary: true
+      }
+    ]
   },
   nostra: {
     tokens: [
@@ -74,9 +87,27 @@ const protocolConfigs = {
       { type: "Liquidity Pool", color: "bg-[#FFF7ED] text-[#EA580C]" },
       { type: "Lend/Borrow", color: "bg-[#EEF6FF] text-[#0369A1]" }
     ],
-    description: "Provide liquidity to the xSTRK/STRK pool, use xSTRK as collateral and swap xSTRK on Nostra"
+    description: "Provide liquidity to the xSTRK/STRK pool, use xSTRK as collateral and swap xSTRK on Nostra",
+    actions: [
+      {
+        type: "swap",
+        link: "https://nostra.finance/swap",
+        buttonText: "Swap Tokens",
+        primary: true
+      },
+      {
+        type: "pool",
+        link: "https://nostra.finance/pools",
+        buttonText: "Add Liquidity"
+      },
+      {
+        type: "lend",
+        link: "https://nostra.finance/lend",
+        buttonText: "Lend Assets"
+      }
+    ]
   }
-} as const;
+};
 
 const Defi: React.FC = () => {
   const { open } = useSidebar();
@@ -111,7 +142,7 @@ const Defi: React.FC = () => {
                 badges={config.badges}
                 description={config.description}
                 apy={shouldShowApy ? yields[protocol] : undefined}
-                link={defiLinks[protocol]}
+                actions={config.actions}
               />
             );
           })}

--- a/src/components/defi.tsx
+++ b/src/components/defi.tsx
@@ -119,10 +119,10 @@ const Defi: React.FC = () => {
         "lg:pl-28": !open,
       })}
     >
-      <h1 className="text-2xl font-semibold tracking-[-1%] text-black">Defi</h1>
-      <p className="text-base font-normal tracking-[-1%] text-[#8D9C9C]">
+      <h1 className="text-2xl font-semibold tracking-[-1%] text-black">Earn extra yield by using your xSTRK on DeFi platforms</h1>
+      {/* <p className="text-base font-normal tracking-[-1%] text-[#8D9C9C]">
         Use xSTRK to unlock greater rewards with DeFi opportunities!
-      </p>
+      </p> */}
 
       <div className="mt-9">
         <div className="mb-6 rounded-md border border-[#17876D33] bg-[#17876D0A] p-4">

--- a/src/components/defi.tsx
+++ b/src/components/defi.tsx
@@ -91,18 +91,18 @@ const protocolConfigs: Record<string, ProtocolConfig> = {
     actions: [
       {
         type: "swap",
-        link: "https://nostra.finance/swap",
+        link: "https://app.nostra.finance/swap",
         buttonText: "Swap Tokens",
         primary: true
       },
       {
         type: "pool",
-        link: "https://nostra.finance/pools",
+        link: "https://app.nostra.finance/pools/xSTRK-STRK/deposit",
         buttonText: "Add Liquidity"
       },
       {
         type: "lend",
-        link: "https://nostra.finance/lend",
+        link: "https://app.nostra.finance/lend-borrow/xSTRK/deposit",
         buttonText: "Lend Assets"
       }
     ]

--- a/src/components/defi.tsx
+++ b/src/components/defi.tsx
@@ -1,12 +1,86 @@
 "use client";
 
+import { useAtomValue } from "jotai";
 import React from "react";
 import { cn } from "@/lib/utils";
 import DefiCard from "./defi-card";
+import { Icons } from "./Icons";
 import { useSidebar } from "./ui/sidebar";
+import { protocolYieldsAtom } from "@/store/defi.store";
+
+const defiLinks = {
+  strkfarm: "",  // not yet available
+  vesu: "https://vesu.xyz/lend",
+  avnu: "https://app.avnu.fi/en?mode=simple&tokenFrom=0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d&tokenTo=0x28d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a&amount=0.001",
+  fibrous: "https://app.fibrous.finance/en?network=starknet&mode=swap&source=0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d&destination=0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a",
+  ekubo: "https://app.ekubo.org/positions/new?baseCurrency=xSTRK&quoteCurrency=STRK&fee=170141183460469235273462165868118016&tickSpacing=1000&poolOnly=true"
+} as const;
+
+const protocolConfigs = {
+  strkfarm: {
+    tokens: [
+      { icon: <Icons.endurLogo className="size-[22px]" />, name: "xSTRK" }
+    ],
+    protocolIcon: <Icons.strkfarmLogo className="size-8" />,
+    badges: [{ type: "Yield Farming", color: "bg-[#E9F3F0] text-[#17876D]" }],
+    description: "Auto compound defi spring rewards on xSTRK"
+  },
+  vesu: {
+    tokens: [
+      { icon: <Icons.endurLogo className="size-[22px]" />, name: "xSTRK" }
+    ],
+    protocolIcon: <Icons.vesuLogo className="size-8 rounded-full" />,
+    badges: [{ type: "Lend/Borrow", color: "bg-[#EEF6FF] text-[#0369A1]" }],
+    description: "Earn DeFi Spring rewards & yield, use xSTRK as collateral to Borrow and Multiply"
+  },
+  avnu: {
+    tokens: [
+      { icon: <Icons.endurLogo className="size-[22px]" />, name: "xSTRK" },
+      { icon: <Icons.strkLogo className="size-[22px]" />, name: "STRK" }
+    ],
+    protocolIcon: <Icons.avnuLogo className="size-8 rounded-full border" />,
+    badges: [{ type: "DEX Aggregator", color: "bg-[#F3E8FF] text-[#9333EA]" }],
+    description: "Swap xSTRK for STRK on Avnu"
+  },
+  fibrous: {
+    tokens: [
+      { icon: <Icons.endurLogo className="size-[22px]" />, name: "xSTRK" },
+      { icon: <Icons.strkLogo className="size-[22px]" />, name: "STRK" }
+    ],
+    protocolIcon: <Icons.fibrousLogo className="size-8 rounded-full" />,
+    badges: [{ type: "DEX Aggregator", color: "bg-[#F3E8FF] text-[#9333EA]" }],
+    description: "Swap xSTRK for STRK on Fibrous"
+  },
+  ekubo: {
+    tokens: [
+      { icon: <Icons.endurLogo className="size-[22px]" />, name: "xSTRK" },
+      { icon: <Icons.strkLogo className="size-[22px]" />, name: "STRK" }
+    ],
+    protocolIcon: <Icons.ekuboLogo className="size-8 rounded-full" />,
+    badges: [
+      { type: "DEX", color: "bg-[#F3E8FF] text-[#9333EA]" },
+      { type: "Liquidity Pool", color: "bg-[#FFF7ED] text-[#EA580C]" }
+    ],
+    description: "Provide liquidity for xSTRK/STRK on Ekubo"
+  },
+  nostra: {
+    tokens: [
+      { icon: <Icons.endurLogo className="size-[22px]" />, name: "xSTRK" },
+      { icon: <Icons.strkLogo className="size-[22px]" />, name: "STRK" }
+    ],
+    protocolIcon: <Icons.nostraLogo className="size-8 rounded-full" />,
+    badges: [
+      { type: "DEX", color: "bg-[#F3E8FF] text-[#9333EA]" },
+      { type: "Liquidity Pool", color: "bg-[#FFF7ED] text-[#EA580C]" },
+      { type: "Lend/Borrow", color: "bg-[#EEF6FF] text-[#0369A1]" }
+    ],
+    description: "Provide liquidity to the xSTRK/STRK pool, use xSTRK as collateral and swap xSTRK on Nostra"
+  }
+} as const;
 
 const Defi: React.FC = () => {
   const { open } = useSidebar();
+  const yields = useAtomValue(protocolYieldsAtom);
 
   return (
     <div
@@ -25,31 +99,22 @@ const Defi: React.FC = () => {
         </p>
 
         <div className="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-2 xl:grid-cols-3">
-          <DefiCard
-            dapp="strkfarm"
-            tokens={["xSTRK", ""]}
-            description="Auto compound defi spring rewards on xSTRK"
-          />
-          <DefiCard
-            dapp="vesu"
-            tokens={["xSTRK", ""]}
-            description="Borrow using xSTRK on Vesu"
-          />
-          <DefiCard
-            dapp="avnu"
-            tokens={["xSTRK", "STRK"]}
-            description="Swap xSTRK for STRK on Avnu"
-          />
-          <DefiCard
-            dapp="fibrous"
-            tokens={["xSTRK", "STRK"]}
-            description="Swap xSTRK for STRK on Fibrous"
-          />
-          <DefiCard
-            dapp="ekubo"
-            tokens={["xSTRK", "STRK"]}
-            description="Provide liquidity for xSTRK/STRK on Ekubo"
-          />
+          {(Object.keys(protocolConfigs) as Array<keyof typeof protocolConfigs>).map((protocol) => {
+            const config = protocolConfigs[protocol];
+            const shouldShowApy = !["avnu", "fibrous"].includes(protocol);
+            
+            return (
+              <DefiCard
+                key={protocol}
+                tokens={config.tokens}
+                protocolIcon={config.protocolIcon}
+                badges={config.badges}
+                description={config.description}
+                apy={shouldShowApy ? yields[protocol] : undefined}
+                link={defiLinks[protocol]}
+              />
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/components/defi.tsx
+++ b/src/components/defi.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import React from "react";
-
 import { cn } from "@/lib/utils";
-
 import DefiCard from "./defi-card";
 import { useSidebar } from "./ui/sidebar";
 

--- a/src/components/stake.tsx
+++ b/src/components/stake.tsx
@@ -455,7 +455,7 @@ const Stake = () => {
       <div className="my-5 h-px w-full rounded-full bg-[#AACBC480]" />
 
       <div className="space-y-3 px-7">
-        <div className="flex items-center justify-between rounded-md text-xs font-semibold text-[#939494] lg:text-[13px]">
+        <div className="flex items-center justify-between rounded-md text-base font-bold text-[#03624C] lg:text-lg">
           <p className="flex items-center gap-1">
             You will get
             <TooltipProvider delayDuration={0}>
@@ -480,11 +480,11 @@ const Stake = () => {
               </Tooltip>
             </TooltipProvider>
           </p>
-          <span>
+          <span className="text-lg lg:text-xl">
             {form.watch("stakeAmount")
               ? formatNumberWithCommas(
-                  Number(form.watch("stakeAmount")) / exchangeRate.rate,
-                )
+                Number(form.watch("stakeAmount")) / exchangeRate.rate,
+              )
               : 0}{" "}
             xSTRK
           </span>
@@ -574,7 +574,7 @@ const Stake = () => {
             type="submit"
             disabled={
               Number(form.getValues("stakeAmount")) <= 0 ||
-              isNaN(Number(form.getValues("stakeAmount")))
+                isNaN(Number(form.getValues("stakeAmount")))
                 ? true
                 : false
             }

--- a/src/components/unstake.tsx
+++ b/src/components/unstake.tsx
@@ -466,7 +466,7 @@ const Unstake = ({ avgWaitTime }: { avgWaitTime: string }) => {
       <div className="mb-5 mt-[14px] h-px w-full rounded-full bg-[#AACBC480]" />
 
       <div className="space-y-3 px-7">
-        <div className="flex items-center justify-between rounded-md text-xs font-semibold text-[#939494] lg:text-[13px]">
+        <div className="flex items-center justify-between rounded-md text-base font-bold text-[#03624C] lg:text-lg">
           <p className="flex items-center gap-1">
             You will get
             <TooltipProvider delayDuration={0}>
@@ -487,7 +487,7 @@ const Unstake = ({ avgWaitTime }: { avgWaitTime: string }) => {
               </Tooltip>
             </TooltipProvider>
           </p>
-          <span>{youWillGet} STRK</span>
+          <span className="text-lg lg:text-xl">{youWillGet} STRK</span>
         </div>
 
         <div className="flex items-center justify-between rounded-md text-xs font-medium text-[#939494] lg:text-[13px]">
@@ -545,7 +545,7 @@ const Unstake = ({ avgWaitTime }: { avgWaitTime: string }) => {
             onClick={form.handleSubmit(onSubmit)}
             disabled={
               Number(form.getValues("unstakeAmount")) <= 0 ||
-              isNaN(Number(form.getValues("unstakeAmount")))
+                isNaN(Number(form.getValues("unstakeAmount")))
                 ? true
                 : false
             }

--- a/src/components/unstake.tsx
+++ b/src/components/unstake.tsx
@@ -41,6 +41,7 @@ import {
   totalStakedAtom,
   totalStakedUSDAtom,
   userSTRKBalanceAtom,
+  userXSTRKBalanceAtom,
 } from "@/store/lst.store";
 import { snAPYAtom } from "@/store/staking.store";
 import { isTxAccepted } from "@/store/transactions.atom";
@@ -85,6 +86,7 @@ const Unstake = ({ avgWaitTime }: { avgWaitTime: string }) => {
   const exRate = useAtomValue(exchangeRateAtom);
   const totalStaked = useAtomValue(totalStakedAtom);
   const totalStakedUSD = useAtomValue(totalStakedUSDAtom);
+  const currentXSTRKBalance = useAtomValue(userXSTRKBalanceAtom);
   const apy = useAtomValue(snAPYAtom);
 
   const form = useForm<FormValues>({
@@ -227,7 +229,7 @@ const Unstake = ({ avgWaitTime }: { avgWaitTime: string }) => {
       });
     }
 
-    const amount = Number(currentStaked.value.toEtherToFixedDecimals(9));
+    const amount = Number(currentXSTRKBalance.value.toEtherToFixedDecimals(9));
 
     if (amount) {
       form.setValue("unstakeAmount", ((amount * percentage) / 100).toString());
@@ -249,13 +251,13 @@ const Unstake = ({ avgWaitTime }: { avgWaitTime: string }) => {
 
     if (
       Number(values.unstakeAmount) >
-      Number(currentStaked.value.toEtherToFixedDecimals(9))
+      Number(currentXSTRKBalance.value.toEtherToFixedDecimals(9))
     ) {
       return toast({
         description: (
           <div className="flex items-center gap-2">
             <Info className="size-5" />
-            Insufficient staked(xSTRK) balance
+            Insufficient xSTRK balance
           </div>
         ),
       });
@@ -385,7 +387,7 @@ const Unstake = ({ avgWaitTime }: { avgWaitTime: string }) => {
             <Icons.wallet className="size-3 lg:size-5" />
             <span className="hidden md:block">Balance:</span>
             <span className="font-bold">
-              {formatNumber(currentStaked.value.toEtherToFixedDecimals(2))}{" "}
+              {formatNumber(currentXSTRKBalance.value.toEtherToFixedDecimals(2))}{" "}
               xSTRK
             </span>
           </div>

--- a/src/components/unstake.tsx
+++ b/src/components/unstake.tsx
@@ -263,7 +263,7 @@ const Unstake = ({ avgWaitTime }: { avgWaitTime: string }) => {
       });
     }
 
-    const call1 = contract.populate("withdraw", [
+    const call1 = contract.populate("redeem", [
       MyNumber.fromEther(values.unstakeAmount, 18),
       address,
       address,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -66,13 +66,16 @@ export function convertTimeString(timeString: string): string {
   if (!match) {
     throw new Error("Invalid time format. Expected format '0 00:00:04.876'");
   }
+  // currently returns upper end of estimate; 
+  // can update as withdrawal queue becomes more automated
 
-  const [_, days, hours, minutes, seconds] = match.map(Number);
+  const hours = parseFloat(`${match[4]}.${match[5]}`);
 
-  if (days > 0) return `${days} ${days === 1 ? "day" : "days"}`;
-  if (hours > 0) return `${hours} ${hours === 1 ? "hour" : "hours"}`;
-  if (minutes > 0) return `${minutes} ${minutes === 1 ? "min" : "mins"}`;
-  if (seconds > 0) return `${seconds} ${seconds === 1 ? "sec" : "secs"}`;
-
-  return "0 secs";
+  if (hours < 1) return "1-2 hours";
+  if (hours < 24) {
+    const roundedHour = Math.ceil(hours);
+    return `${roundedHour}-${roundedHour + 2} hours`;
+  }
+  const days = Math.ceil(hours / 24);
+  return `${days}-${days + 1} days`;
 }

--- a/src/store/defi.store.ts
+++ b/src/store/defi.store.ts
@@ -1,0 +1,172 @@
+import { atom } from "jotai";
+import { atomWithQuery } from "jotai-tanstack-query";
+
+interface VesuAPIResponse {
+  data: {
+    assets: Array<{
+      stats: {
+        supplyApy: {
+          value: string;
+          decimals: number;
+        };
+        defiSpringSupplyApr: {
+          value: string;
+          decimals: number;
+        };
+      };
+    }>;
+  };
+}
+
+interface EkuboPair {
+    token0: {
+      name: string;
+      symbol: string;
+    };
+    token1: {
+      name: string;
+      symbol: string;
+    };
+    currentApr: number;
+    consideredTvl: number;
+  }
+
+interface EkuboAPIResponse {
+    strkPrice: number;
+    totalStrk: number;
+    pairs: EkuboPair[];
+}
+
+interface ProtocolYield {
+  value: number | null;
+  isLoading: boolean;
+  error?: string;
+}
+
+const convertVesuValue = (value: string, decimals: number): number => {
+  const numValue = Number(value);
+  if (isNaN(numValue)) return 0;
+  return numValue / Math.pow(10, decimals);
+};
+
+const findEndurPair = (pairs: EkuboPair[]): EkuboPair | undefined => {
+    return pairs.find(pair => 
+      (pair.token0.symbol === "xSTRK" && pair.token1.symbol === "STRK") ||
+      (pair.token0.symbol === "STRK" && pair.token1.symbol === "xSTRK")
+    );
+};
+
+const vesuYieldQueryAtom = atomWithQuery(() => ({
+  queryKey: ["vesuYield"],
+  queryFn: async (): Promise<ProtocolYield> => {
+    try {
+      const response = await fetch(
+        "https://api.vesu.xyz/pools/2345856225134458665876812536882617294246962319062565703131100435311373119841"
+      );
+      const data: VesuAPIResponse = await response.json();
+      
+      const stats = data.data.assets[0].stats;
+      const supplyApy = convertVesuValue(
+        stats.supplyApy.value,
+        stats.supplyApy.decimals
+      );
+      const defiSpringApr = convertVesuValue(
+        stats.defiSpringSupplyApr.value,
+        stats.defiSpringSupplyApr.decimals
+      );
+
+      return {
+        value: (supplyApy + defiSpringApr) * 100,
+        isLoading: false
+      };
+    } catch (error) {
+      console.error("vesuYieldQueryAtom error:", error);
+      return {
+        value: null,
+        isLoading: false,
+        error: "Failed to fetch Vesu yield"
+      };
+    }
+  },
+  refetchInterval: 60000 
+}));
+
+const ekuboYieldQueryAtom = atomWithQuery(() => ({
+    queryKey: ["ekuboYield"],
+    queryFn: async (): Promise<ProtocolYield> => {
+      try {
+        const response = await fetch("https://mainnet-api.ekubo.org/defi-spring-incentives");
+        const data: EkuboAPIResponse = await response.json();
+        
+        const endurPair = findEndurPair(data.pairs);
+        
+        if (!endurPair) {
+          return {
+            value: null,
+            isLoading: false,
+            error: "Endur pair not found"
+          };
+        }
+  
+        return {
+          value: endurPair.currentApr * 100,
+          isLoading: false
+        };
+      } catch (error) {
+        console.error("ekuboYieldQueryAtom error:", error);
+        return {
+          value: null,
+          isLoading: false,
+          error: "Failed to fetch Ekubo yield"
+        };
+      }
+    },
+    refetchInterval: 60000
+}));
+
+const strkFarmYieldQueryAtom = atomWithQuery(() => ({
+  queryKey: ["strkFarmYield"],
+  queryFn: async (): Promise<ProtocolYield> => {
+    return {
+      value: null,
+      isLoading: false,
+      error: "Coming soon"
+    };
+  },
+  refetchInterval: 60000
+}));
+
+export const vesuYieldAtom = atom((get) => {
+  const { data, error } = get(vesuYieldQueryAtom);
+  return {
+    value: error || !data ? null : data.value,
+    error,
+    isLoading: !data && !error,
+  };
+});
+
+export const ekuboYieldAtom = atom((get) => {
+  const { data, error } = get(ekuboYieldQueryAtom);
+  return {
+    value: error || !data ? null : data.value,
+    error,
+    isLoading: !data && !error,
+  };
+});
+
+export const strkFarmYieldAtom = atom((get) => {
+  const { data, error } = get(strkFarmYieldQueryAtom);
+  return {
+    value: error || !data ? null : data.value,
+    error,
+    isLoading: !data && !error,
+  };
+});
+
+export const protocolYieldsAtom = atom((get) => ({
+  strkfarm: get(strkFarmYieldAtom),
+  vesu: get(vesuYieldAtom),
+  avnu: { value: null, isLoading: false }, 
+  fibrous: { value: null, isLoading: false },
+  ekubo: get(ekuboYieldAtom),
+}));


### PR DESCRIPTION
1. Updating Stake UI
<img width="625" alt="image" src="https://github.com/user-attachments/assets/e8d8bc37-2361-42bc-81c8-686271497955" />

2. Updating unstake UI to correctly display average withdrawal queue time
<img width="625" alt="image" src="https://github.com/user-attachments/assets/17968aff-bc4c-480a-8b9b-8e2c887b1593" />

3. Updating DeFi screens with Apps and Yields (need to add Nostra and Opus)
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/432bbbf7-9c70-4c47-92dd-1e3b8b547139" />

4. Fixed Sidebar (DeFi) title

5. Fixed Avnu/Fibrous/Ekubo URLs

6. Updated unstake tab to read xSTRK balance and display/use the same next to input field

7. Added Audit Link to Header

8. Updated DeFi screen with Nostra

9. Changed "redeem" call instead of "withdraw", @akiraonstarknet there is no "approve" call needed for this? Not sure