### PR TITLE
fix: remove analytics sitemap

### DIFF
--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -4,4 +4,3 @@ Sitemap: https://app.endur.fi/sitemap.xml
 Sitemap: https://blog.endur.fi/sitemap.xml
 Sitemap: https://dashboard.endur.fi/sitemap.xml
 Sitemap: https://docs.endur.fi/docs/sitemap.xml
-Sitemap: https://analytics.endur.fi/sitemap.xml


### PR DESCRIPTION
removed the mention of analytics' sitemap since we're not going to add it