### PR TITLE
fix: reset Privy connection on failure

### DIFF
--- a/src/app/api/wallet/create/route.ts
+++ b/src/app/api/wallet/create/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPrivy } from "@/lib/privy";
-import { getPrisma } from "@/lib/prisma";
+import { getPrisma, PrismaClientType } from "@/lib/prisma";
 
 export async function POST(request: NextRequest) {
   try {
@@ -34,19 +34,35 @@ export async function POST(request: NextRequest) {
 
     const userId = verifiedClaims.user_id;
 
-    const prisma = (await getPrisma()) as any;
-    const existingWallet = await prisma.wallet.findUnique({
-      where: { privyUserId: userId },
-    });
-    if (existingWallet) {
-      return NextResponse.json({
-        wallet: {
-          id: existingWallet.id,
-          walletId: existingWallet.walletId,
-          address: existingWallet.address,
-          publicKey: existingWallet.publicKey,
-        },
+    let prisma: PrismaClientType;
+    try {
+      prisma = await getPrisma();
+    } catch (err) {
+      // If the DB is down / prisma fails, returning a raw 500 here can put
+      // the upstream client SDK into a sticky error state until refresh.
+      // Degrade gracefully: respond 200 with wallet:null so the client can
+      // retry connection flows without a full reload.
+      return NextResponse.json({ wallet: null });
+    }
+
+    try {
+      const existingWallet = await prisma.wallet.findUnique({
+        where: { privyUserId: userId },
       });
+      if (existingWallet) {
+        return NextResponse.json({
+          wallet: {
+            id: existingWallet.id,
+            walletId: existingWallet.walletId,
+            address: existingWallet.address,
+            publicKey: existingWallet.publicKey,
+          },
+        });
+      }
+    } catch (err) {
+      // See above: if Prisma fails, degrade gracefully so the client can
+      // re-run its auth/connect flow.
+      return NextResponse.json({ wallet: null });
     }
 
     const wallet = await privy.wallets().create({
@@ -59,27 +75,38 @@ export async function POST(request: NextRequest) {
       ],
     });
 
-    const newWallet = await prisma.wallet.create({
-      data: {
-        privyUserId: userId,
-        walletId: wallet.id,
-        address: wallet.address,
-        publicKey: wallet.public_key,
-        isDeployed: false,
-      },
-    });
+    if (!wallet.public_key) {
+      return NextResponse.json({ wallet: null });
+    }
 
-    return NextResponse.json({
-      wallet: {
-        id: newWallet.id,
-        walletId: newWallet.walletId,
-        address: newWallet.address,
-        publicKey: newWallet.publicKey,
-      },
-    });
+    try {
+      const newWallet = await prisma.wallet.create({
+        data: {
+          privyUserId: userId,
+          walletId: wallet.id,
+          address: wallet.address,
+          publicKey: wallet.public_key,
+          isDeployed: false,
+        },
+      });
+
+      return NextResponse.json({
+        wallet: {
+          id: newWallet.id,
+          walletId: newWallet.walletId,
+          address: newWallet.address,
+          publicKey: newWallet.publicKey,
+        },
+      });
+    } catch (err) {
+      // DB failed while persisting the wallet. Do not return a wallet object.
+      // Let the client reset and retry once DB is healthy.
+      return NextResponse.json({ wallet: null });
+    }
   } catch (error: unknown) {
     if (error instanceof Error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+    return NextResponse.json({ error: "Unknown error" }, { status: 500 });
   }
 }

--- a/src/app/api/wallet/route.ts
+++ b/src/app/api/wallet/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPrivy } from "@/lib/privy";
-import { getPrisma } from "@/lib/prisma";
+import { getPrisma, PrismaClientType } from "@/lib/prisma";
 
 export async function GET(request: NextRequest) {
   try {
@@ -27,26 +27,34 @@ export async function GET(request: NextRequest) {
 
     const userId = verifiedClaims.user_id;
 
-    const prisma = (await getPrisma()) as any;
-    const wallet = await prisma.wallet.findUnique({
-      where: { privyUserId: userId },
-    });
+    try {
+      const prisma: PrismaClientType = await getPrisma();
+      const wallet = await prisma.wallet.findUnique({
+        where: { privyUserId: userId },
+      });
+      if (!wallet) {
+        return NextResponse.json({ wallet: null });
+      }
 
-    if (!wallet) {
+      return NextResponse.json({
+        wallet: {
+          id: wallet.id,
+          walletId: wallet.walletId,
+          address: wallet.address,
+          publicKey: wallet.publicKey,
+        },
+      });
+    } catch (err) {
+      // If the DB is down / prisma fails, returning a raw 500 here can put
+      // the upstream client SDK into a sticky error state until refresh.
+      // Degrade gracefully: respond 200 with wallet:null so the client can
+      // retry connection flows without a full reload.
       return NextResponse.json({ wallet: null });
     }
-
-    return NextResponse.json({
-      wallet: {
-        id: wallet.id,
-        walletId: wallet.walletId,
-        address: wallet.address,
-        publicKey: wallet.publicKey,
-      },
-    });
   } catch (error: unknown) {
     if (error instanceof Error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+    return NextResponse.json({ error: "Unknown error" }, { status: 500 });
   }
 }

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -12,6 +12,7 @@ import { endurEasyleapTheme } from "@/constants/easyleap-theme";
 import { NETWORK } from "@/constants";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
+import { installPrivyResetInstrumentation } from "@/lib/privy-reset";
 import { WalletConnector } from "@/services/wallet";
 
 import "@easyleap/sdk/styles.css";
@@ -54,9 +55,17 @@ const provider = jsonRpcProvider({
 const Providers: React.FC<ProvidersProps> = ({ children }) => {
   const isMobile = useIsMobile();
   const walletConnector = new WalletConnector(isMobile);
+  const [easyleapRemountKey, setEasyleapRemountKey] = React.useState(0);
+
+  React.useEffect(() => {
+    return installPrivyResetInstrumentation({
+      onReset: () => setEasyleapRemountKey((k) => k + 1),
+    });
+  }, []);
 
   return (
     <EasyleapProvider
+      key={easyleapRemountKey}
       theme={endurEasyleapTheme}
       privyAppId={privyAppId}
       starkzap={{

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -7,7 +7,7 @@
  * (before route handlers execute).
  */
 
-export type PrismaClientType = unknown;
+export type PrismaClientType = import("@prisma/client").PrismaClient;
 
 declare global {
   // eslint-disable-next-line no-var
@@ -15,11 +15,11 @@ declare global {
 }
 
 export async function getPrisma() {
-  if (globalThis.prisma) return globalThis.prisma as any;
+  if (globalThis.prisma) return globalThis.prisma;
 
   try {
     const mod = await import("@prisma/client");
-    const PrismaClient = (mod as any).PrismaClient as any;
+    const PrismaClient = mod.PrismaClient;
     const prisma = new PrismaClient({
       log:
         process.env.NODE_ENV === "development"
@@ -29,11 +29,10 @@ export async function getPrisma() {
 
     if (process.env.NODE_ENV !== "production") globalThis.prisma = prisma;
 
-    return prisma;
+    return prisma as PrismaClientType;
   } catch (err: any) {
     throw new Error(
       "Prisma client is not generated. Run `pnpm approve-builds` then `pnpm prisma generate` (or reinstall), and restart the dev server.",
     );
   }
 }
-

--- a/src/lib/privy-reset.ts
+++ b/src/lib/privy-reset.ts
@@ -1,0 +1,127 @@
+export type InstallPrivyResetInstrumentationOptions = {
+  onReset: () => void;
+};
+
+export function installPrivyResetInstrumentation(
+  opts: InstallPrivyResetInstrumentationOptions,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const resetPrivyStateOnce = () => {
+    const w = window as unknown as { __endurPrivyResetDone?: boolean };
+    if (w.__endurPrivyResetDone) return;
+    w.__endurPrivyResetDone = true;
+
+    const keysToClear = [
+      // session/auth
+      "privy:token",
+      "privy:pat",
+      "privy:refresh_token",
+      // oauth handshake
+      "privy:state_code",
+      "privy:code_verifier",
+      // connections cache
+      "privy:connections",
+    ];
+    for (const k of keysToClear) {
+      try {
+        if (window.localStorage.getItem(k) !== null) {
+          window.localStorage.removeItem(k);
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    opts.onReset();
+  };
+
+  const w = window as unknown as {
+    fetch?: typeof window.fetch;
+    __endurFetchInstrumented?: boolean;
+  };
+
+  if (!w.__endurFetchInstrumented && typeof w.fetch === "function") {
+    const originalFetch = w.fetch.bind(window);
+    w.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+
+      const isPrivyBackedEndpoint =
+        url === "/api/wallet" ||
+        url === "/api/wallet/create" ||
+        url === "/api/wallet/sign" ||
+        url === "/api/paymaster";
+
+      let res: Response;
+      try {
+        res = await originalFetch(input as any, init as any);
+      } catch (err) {
+        if (isPrivyBackedEndpoint) {
+          resetPrivyStateOnce();
+        }
+        throw err;
+      }
+
+      try {
+        if (isPrivyBackedEndpoint && !res.ok) {
+          resetPrivyStateOnce();
+        } else if (
+          (url === "/api/wallet" || url === "/api/wallet/create") &&
+          res.ok
+        ) {
+          res
+            .clone()
+            .json()
+            .then((body) => {
+              const b = body as any;
+              const shouldReset =
+                b &&
+                typeof b === "object" &&
+                "wallet" in b &&
+                b.wallet === null;
+              if (!shouldReset) return;
+              resetPrivyStateOnce();
+            })
+            .catch(() => {});
+        } else if (url === "/api/paymaster" && res.ok) {
+          // JSON-RPC errors are returned with HTTP 200; detect error envelope.
+          res
+            .clone()
+            .json()
+            .then((body) => {
+              const b = body as any;
+              if (!b || typeof b !== "object") return;
+              if ("error" in b) {
+                resetPrivyStateOnce();
+              }
+            })
+            .catch(() => {});
+        } else if (url === "/api/wallet/sign" && res.ok) {
+          // If the route responds with an error envelope but 200, reset anyway.
+          res
+            .clone()
+            .json()
+            .then((body) => {
+              const b = body as any;
+              if (!b || typeof b !== "object") return;
+              if ("error" in b) {
+                resetPrivyStateOnce();
+              }
+            })
+            .catch(() => {});
+        }
+      } catch {
+        // ignore
+      }
+
+      return res;
+    }) as any;
+    w.__endurFetchInstrumented = true;
+  }
+  return () => {};
+}


### PR DESCRIPTION
## Summary
- Return `wallet: null` when an error occurs in any Privy backend endpoint to avoid putting the SDK in an error state until refresh.
- Clear Privy related auth credentials on error to allow retries without refresh
